### PR TITLE
fix: fix badge component

### DIFF
--- a/src/components/badge/badge.vue
+++ b/src/components/badge/badge.vue
@@ -16,7 +16,9 @@ export default {
   },
   computed: {
     currentText () {
-      if (this.text > this.overflowCount) {
+      if (this.dot) {
+        return null
+      } else if (this.text > this.overflowCount) {
         return this.overflowCount + '+'
       } else {
         return this.text

--- a/src/components/badge/style/index.less
+++ b/src/components/badge/style/index.less
@@ -27,7 +27,7 @@
     transform: translateX(-45%);
     transform-origin: -10% center;
     z-index: 10;
-    font-family: "Helvetica Neue", Helvetica, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "\5FAE\8F6F\96C5\9ED1", SimSun, sans-serif;
+    font-family: 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', '\5FAE\8F6F\96C5\9ED1', SimSun, sans-serif;
 
     a {
       color: @color-text-base-inverse;
@@ -83,6 +83,7 @@
 
     &-wrapper {
       overflow: hidden;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
以下2点小问题
1.`<cb-badge :text="num" :dot="num>99"></cb-badge>`可以动态改变badge的状态，如我们的微信群消息达到一定上限时变成dot，
2.设置corner属性时没有继承父容器的宽度。